### PR TITLE
Removed PositionsProperty

### DIFF
--- a/lib/util.gd
+++ b/lib/util.gd
@@ -6,16 +6,6 @@
 # Declares functions which are not specific to QPA.  That is, they
 # could have been a part of GAP itself, but they are not.
 
-
-# PositionsProperty( list, fun ):
-
-# Gives the indices of all elements in list for which fun returns
-# true.  (This is like the builtin PositionProperty, except that it
-# gives the indices of all such elements, not just the first).
-
-DeclareOperation( "PositionsProperty", [ IsList, IsFunction ] );
-
-
 # PositionsNonzero( list ):
 
 # Gives the indices of all nonzero elements in list.

--- a/lib/util.gi
+++ b/lib/util.gi
@@ -1,22 +1,6 @@
 # GAP Implementation
 # $Id: util.gi,v 1.1 2011/04/28 09:36:47 oysteini Exp $
 
-InstallMethod( PositionsProperty,
-        "for a list and a function",
-        [ IsList, IsFunction ],
-        function( list, fun )
-    local positions, i;
-
-    positions := [ ];
-    for i in [ 1 .. Length( list ) ] do
-        if fun( list[ i ] ) then
-            Append( positions, [ i ] );
-        fi;
-    od;
-
-    return positions;
-end );
-
 
 InstallMethod( PositionsNonzero,
         "for a list",


### PR DESCRIPTION
In the latest GAP version, there is a built-in version of PositionsProperty. It is installed also installed for `IsList`, and does also work on non-dense list.

So there is no need to keep the function in QPA, specially since it does not work on non-dense lists and overwrites the appropriate library function.