### PR TITLE
Fixed a bug in StarOfModule.

### DIFF
--- a/lib/functors.gi
+++ b/lib/functors.gi
@@ -453,7 +453,7 @@ InstallMethod( StarOfModule,
     for b in BV do
         if Length(b) <> 0 then 
             Add(BasisVflat, 
-                Basis(Subspace(FullRowSpace(K, Length(b[1])), b, "basis"))); 
+                Basis(Subspace(FullRowSpace(K, Length(b[1])), b, "basis"), b)); 
         else 
             Add(BasisVflat, []);
         fi;


### PR DESCRIPTION
This should fix #9. I ran across the bug in the following example:

```
Q := Quiver(3, [
  [1, 2, "a"],
  [2, 1, "b"],
  [2, 3, "c"],
  [3, 2, "d"]
]);

kQ := PathAlgebra(Rationals, Q);
AssignGeneratorVariables(kQ);

A := kQ/[a*b, b*a-c*d];

M := RightModuleOverPathAlgebra(A, [
  ["a", [[1]]],
  ["b", [[0]]],
  ["c", [[1,0]]],
  ["d", [[0],[-1]]],
]);

StarOfM := StarOfModule(M);
# output: The entered matrices for the module do not satisfy the relation(s).
```