### PR TITLE
Fixed a bug in RestrictionViaAlgebraHomomorphism.

### DIFF
--- a/lib/module.gi
+++ b/lib/module.gi
@@ -2263,14 +2263,17 @@ InstallMethod( RestrictionViaAlgebraHomomorphism,
     vertices := One( A ) * VerticesOfQuiver( QuiverOfPathAlgebra( A ) );
     V := List( vertices, v -> List( BasisVectors( Basis( M ) ), m -> m ^ ImageElm( f, v ) ) ); 
     V := List( V, W -> Filtered( W, w -> w <> Zero( w ) ) );
-    V := List( V, W -> VectorSpace( K, W ) );
-    BV := List( V, W -> Basis( W ) );
+    BV := List( V, function( W ) if IsEmpty(W) then return []; else return Basis( VectorSpace( K, W ) ); fi; end );
     arrows := ArrowsOfQuiver( QuiverOfPathAlgebra( A ) );
     mats := [ ]; 
     for a in arrows do
         startpos := Position( vertices, One( A ) * SourceOfPath ( a ) );
         endpos := Position( vertices, One( A ) * TargetOfPath ( a ) );        
-        Add( mats, List( BV[ startpos ], m -> Coefficients( BV[ endpos ], m ^ ImageElm( f, One( A ) * a ) ) ) );
+        if IsEmpty( BV[ startpos ] ) or IsEmpty( BV[ endpos ] ) then
+            Add( mats, [ a, [ Length( BV[ startpos ] ), Length( BV[ endpos ] ) ] ] );
+        else
+            Add( mats, [ a, List( BV[ startpos ], m -> Coefficients( BV[ endpos ], m ^ ImageElm( f, One( A ) * a ) ) ) ] );
+        fi;
     od;
     
     return RightModuleOverPathAlgebra( A, mats ); 


### PR DESCRIPTION
This should fix a problem with `RestrictionViaAlgebraHomomorphism`. The problem occurs for example when running the code below:
```
Q := Quiver(2, [[1, 2, "a"]]);
A := PathAlgebra(Rationals, Q);
Aenv := EnvelopingAlgebra(A);

f := TensorAlgebraInclusion(Aenv, 2);
M := SimpleModules(Aenv)[1];

fM := RestrictionViaAlgebraHomomorphism(f, M);
```
This leads to the unexpected error message:
```
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `LeftModuleByGenerators' on 2 arguments called from
LeftModuleByGenerators( arg[1], arg[2] ) at .../lib/gap4r8/lib/modfree.gi:415 called from
CallFuncList( FreeLeftModule, arg ) at .../lib/gap4r8/lib/vspc.gi:61 called from
VectorSpace( K, W ) at .../lib/gap4r8/pkg/qpa-1.27/lib/module.gi:2266 called from
func( C[i] ) at .../lib/gap4r8/lib/coll.gi:746 called from
List( V, function ( W )
      return VectorSpace( K, W );
  end ) at .../lib/gap4r8/pkg/qpa-1.27/lib/module.gi:2266 called from
```
