### PR TITLE
Turn IsDirectSumOfModules into a pure filter

### DIFF
--- a/doc/chapter_right_modules.xml
+++ b/doc/chapter_right_modules.xml
@@ -472,7 +472,7 @@ gap> N := RightModuleOverPathAlgebra(A,mat);
    <Returns>the direct sum of the representations contained in the
      list <Arg>L</Arg>.</Returns>
    <Description>In addition three attributes are attached to the
-   result, <Ref Attr="IsDirectSumOfModules"/>, <Ref
+   result, <Ref Filt="IsDirectSumOfModules"/>, <Ref
    Attr="DirectSumProjections"/> <Ref Attr="DirectSumInclusions"/>.
    </Description>
 </ManSection>
@@ -540,7 +540,7 @@ gap> N := RightModuleOverPathAlgebra(A,mat);
 </ManSection>
 
 <ManSection>
-   <Attr Name="IsDirectSumOfModules" Arg="M" Comm="for a PathAlgebraMatModule"/>
+   <Filt Name="IsDirectSumOfModules" Arg="M" Comm="for a PathAlgebraMatModule"/>
    <Description> 
     Arguments: <Arg>M</Arg> -- a path algebra module (<C>PathAlgebraMatModule</C>).
    <Br /></Description>

--- a/lib/module.gd
+++ b/lib/module.gd
@@ -32,7 +32,7 @@ InstallTrueMethod( IsIndecomposableModule, IsSimpleQPAModule );
 DeclareProperty( "IsSemisimpleModule", IsPathAlgebraMatModule );
 InstallTrueMethod( IsSemisimpleModule, IsSimpleQPAModule );
 DeclareOperation( "DirectSumOfQPAModules", [ IsList] );
-DeclareAttribute( "IsDirectSumOfModules", IsPathAlgebraMatModule );
+DeclareFilter( "IsDirectSumOfModules", IsPathAlgebraMatModule );
 DeclareAttribute( "DirectSumProjections", IsPathAlgebraMatModule );
 DeclareAttribute( "DirectSumInclusions", IsPathAlgebraMatModule );
 DeclareOperation( "SupportModuleElement", [ IsRightAlgebraModuleElement ] );

--- a/lib/module.gi
+++ b/lib/module.gi
@@ -1907,7 +1907,7 @@ InstallMethod( DirectSumOfQPAModules,
          Add( list_of_incls, RightModuleHomOverAlgebra( L[ i ], direct_sum, maps ) );
       od;
 
-      SetIsDirectSumOfModules( direct_sum, true );
+      SetFilterObj( direct_sum, IsDirectSumOfModules );
       SetDirectSumProjections( direct_sum, list_of_projs );
       SetDirectSumInclusions( direct_sum, list_of_incls );
 
@@ -1918,25 +1918,6 @@ InstallMethod( DirectSumOfQPAModules,
 end
 );
 
-
-#######################################################################
-##
-#P  IsDirectSumOfModules( <M> )
-##
-##  <M> is a module over a path algebra. The function checks if the
-##  property "IsDirectSumOfModules" is set to true for M, and returns
-##  true if it is, and false if it is not. (Note that this is NOT a
-##  check for indecomposability.)
-##
-InstallMethod( IsDirectSumOfModules,
-   "for a module over a path algebra",
-   [ IsPathAlgebraMatModule ], 0,
-   function( M )
-   
-   return "IsDirectSumOfModules" in KnownTruePropertiesOfObject(M);
-
-end
-);
 
 #######################################################################
 ##


### PR DESCRIPTION
IsDirectSumOfModules is not a property or attribute that can be set to true or false due to a later computation; rather, it can only be set when creating an object via a special constructor.

That suggests it should simply be a filter, not an attribute.

This makes qpa compatible with this upcoming GAP change: <https://github.com/gap-system/gap/pull/2732>