### PR TITLE
Switch to TestDirectory

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -92,7 +92,7 @@ AvailabilityTest := ReturnTrue,
                    
 Autoload := false,
 
-TestFile := "tst/testall.tst",
+TestFile := "tst/testall.g",
 
 Keywords := ["quiver","path algebra"]
 ));

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,0 +1,6 @@
+LoadPackage("qpa");
+dir := DirectoriesPackageLibrary("qpa", "tst");
+TestDirectory(dir, rec(exitGAP := true,
+                       testOptions:=rec(compareFunction:="uptowhitespace")));
+
+FORCE_QUIT_GAP(1);

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -391,3 +391,7 @@ gap> QuadraticFormOfUnitForm(u);
 function( x ) ... end
 gap> SymmetricMatrixOfUnitForm(u);
 [ [ 2, -1, 0 ], [ -1, 2, -1 ], [ 0, -1, 2 ] ]
+
+#
+gap> STOP_TEST("qpa.tst");
+


### PR DESCRIPTION
This puts the test code into testall.g which will test now all .tst files in the tst directory - adding new test file will only require to add that file, no other adjustments will be needed elsewhere. It also specifies the new testall.g as a default test in PackageInfo.g, and adds a missing STOP_TEST call.