### PR TITLE
Get rid of GBNP dependency.

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -82,7 +82,6 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">=4.5",
-  NeededOtherPackages := [["GBNP", ">=0.9.5"]],
   SuggestedOtherPackages := [],
   ExternalConditions := []
                       

--- a/lib/gbnp.gd
+++ b/lib/gbnp.gd
@@ -1,20 +1,20 @@
 DeclareOperation( "GBNPGroebnerBasis",
     [ IsList, IsPathAlgebra ] );
 
-DeclareOperation( "GBNPGroebnerBasisNC",
+DeclareOperation( "RemainderOfDivision",
+    [ IsElementOfMagmaRingModuloRelations, IsList, IsPathAlgebra ] );
+
+DeclareOperation( "ReducedList",
     [ IsList, IsPathAlgebra ] );
 
-DeclareOperation( "GBNPGroebnerBasis",
-    [ IsFLMLOR ] );
-
-DeclareOperation( "QPA_Path2Cohen",
-    [ IsList ] );
-
-DeclareOperation( "QPA_Path2CohenFree",
-    [ IsList ] );
-
-DeclareOperation( "QPA_Cohen2Path",
+DeclareOperation( "TipReducedList",
     [ IsList, IsPathAlgebra ] );
+
+DeclareOperation( "LeftmostOccurrence",
+    [ IsList, IsList ] );
+
+DeclareSynonym( "TipWalk",
+    x -> WalkOfPath(TipMonomial(x)) );
 
 DeclareOperation( "MakeUniform",
     [ IsElementOfMagmaRingModuloRelations ] );

--- a/lib/pathalgideal.gi
+++ b/lib/pathalgideal.gi
@@ -65,14 +65,14 @@ InstallTrueMethod( IsIdealInPathAlgebra,
 #O  \in(<elt>, <I>)
 ##
 ##  This function performs a membership test for an ideal in path algebra using 
-##  GBNP Groebner Bases machinery.
+##  Groebner Bases machinery.
 ##  It returns true if <elt> is a member of an ideal <I>, false otherwise.
 ##  For the efficiency reasons, it computes Groebner basis
 ##  for <I> only if it has not been computed. Similarly, it performs
 ##  CompletelyReduceGroebnerBasis only if it has not been reduced yet.
 ##  The method can change the existing Groebner basis (cf. the code).
 ##  It computes Groebner basis only in case <I> is in the arrow 
-##  ideal. (There are bugs in GBNPGroebnerBasisNC!)
+##  ideal.
 ##	
 InstallMethod(\in,
 	"for a path algebra element and an ideal - membership test using Groebner bases",


### PR DESCRIPTION
This is an attempt to address #20. Instead of using the GBNP package, it implements the algorithm described in https://link.springer.com/chapter/10.1007/978-3-0348-8716-8_2 directly with QPA.

Are there realistic examples where such a high-level implementation would lead to a significant loss of overall performance in comparison to the current GBNP version?