### PR TITLE
Let the user choose what function to use for the computation of Groebner bases.

### DIFF
--- a/init.g
+++ b/init.g
@@ -23,6 +23,7 @@ ReadPackage("QPA", "lib/projpathalgmodule.gd");
 ReadPackage("QPA", "lib/moduledecomp.gd");
 ReadPackage("QPA", "lib/idempotent.gd");
 ReadPackage("QPA", "lib/gbnp.gd");
+ReadPackage("QPA", "lib/gbhighlevel.gd");
 ReadPackage("QPA", "lib/moduleprojres.gd");
 ReadPackage("QPA", "lib/pathalgtensor.gd");
 ReadPackage("QPA", "lib/pathalgpredef.gd");

--- a/lib/gbhighlevel.gd
+++ b/lib/gbhighlevel.gd
@@ -1,0 +1,4 @@
+DeclareOperation( "HighLevelGroebnerBasis", [ IsList, IsPathAlgebra ] );
+DeclareOperation( "RemainderOfDivision", [ IsElementOfMagmaRingModuloRelations, IsList, IsPathAlgebra ] );
+DeclareOperation( "LeftmostOccurrence", [ IsList, IsList ] );
+DeclareSynonym( "TipWalk", x -> WalkOfPath(TipMonomial(x)) );

--- a/lib/gbhighlevel.gd
+++ b/lib/gbhighlevel.gd
@@ -1,4 +1,6 @@
 DeclareOperation( "HighLevelGroebnerBasis", [ IsList, IsPathAlgebra ] );
 DeclareOperation( "RemainderOfDivision", [ IsElementOfMagmaRingModuloRelations, IsList, IsPathAlgebra ] );
+DeclareOperation( "ReducedList", [ IsList, IsPathAlgebra ] );
+DeclareOperation( "TipReducedList", [ IsList, IsPathAlgebra ] );
 DeclareOperation( "LeftmostOccurrence", [ IsList, IsList ] );
 DeclareSynonym( "TipWalk", x -> WalkOfPath(TipMonomial(x)) );

--- a/lib/gbhighlevel.gi
+++ b/lib/gbhighlevel.gi
@@ -1,0 +1,113 @@
+InstallMethod( HighLevelGroebnerBasis,
+  "compute a complete Groebner Basis",
+  [ IsList, IsPathAlgebra ],
+  function(els, A)
+    local gb, el, el_tip,
+          n, i, j, x, y, k, l, r, b, c,
+          overlap, remainder;
+
+    if not QPA_InArrowIdeal(els, A) then
+      Error("elements do not belong to the arrow ideal of the path algebra");
+    fi;
+
+    els := MakeUniform(els);
+
+    gb := [];
+
+    while Length(els) > 0 do
+      for el in els do
+        el_tip := Tip(el);
+        Add(gb, el/TipCoefficient(el_tip));
+      od;
+
+      n := Length(gb);
+      els := [];
+
+      for i in [1..n] do
+        x := TipWalk(gb[i]);
+        k := Length(x);
+
+        for j in [1..n] do
+          y := TipWalk(gb[j]);
+          l := Length(y);
+
+          for r in [Maximum(0, k-l)..k-1] do
+            if x{[r+1..k]} = y{[1..k-r]} then
+              b := x{[1..r]};
+              c := y{[k-r+1..l]};
+
+              overlap := gb[i]*Product(c, One(A)) - Product(b, One(A))*gb[j];
+              remainder := RemainderOfDivision(overlap, gb, A);
+
+              if not IsZero(remainder) then
+                AddSet(els, remainder);
+              fi;
+            fi;
+          od;
+        od;
+      od;
+    od;
+
+    return gb;
+  end
+);
+
+
+InstallMethod( RemainderOfDivision,
+  "for a path-algebra element and a list of monic path-algebra elements",
+  [ IsElementOfMagmaRingModuloRelations, IsList, IsPathAlgebra ],
+  function(y, X, A)
+    local r, n, y_tip, y_wtip, divided, i, p, u, v;
+
+    r := Zero(A);
+    n := Length(X);
+
+    while not IsZero(y) do
+      y_tip := Tip(y);
+      y_wtip := TipWalk(y_tip);
+
+      divided := false;
+
+      for i in [1..n] do
+        p := LeftmostOccurrence(y_wtip, TipWalk(X[i]));
+
+        if p <> fail then
+          u := Product(y_wtip{[1..p[1]-1]}, One(A));
+          v := Product(y_wtip{[p[2]+1..Length(y_wtip)]}, One(A));
+
+          y := y - TipCoefficient(y_tip) * u*X[i]*v;
+
+          divided := true;
+          break;
+        fi;
+      od;
+
+      if not divided then
+        r := r + y_tip;
+        y := y - y_tip;
+      fi;
+    od;
+
+    return r;
+  end
+);
+
+
+InstallMethod( LeftmostOccurrence,
+  "find second list as sublist of first list",
+  [ IsList, IsList ],
+  function(b, c)
+    local lb, lc, i;
+
+    lb := Length(b);
+    lc := Length(c);
+
+    for i in [1..lb-lc+1] do
+      if b{[i..i+lc-1]} = c then
+        return [i, i+lc-1];
+      fi;
+    od;
+
+    return fail;
+  end
+);

--- a/lib/modulehom.gi
+++ b/lib/modulehom.gi
@@ -3692,7 +3692,7 @@ InstallMethod( EndOfModuleAsQuiverAlgebra,
         f := [AA,EndM,gensofAA{[1..Length(gensofAA)]},images];
 
     else
-        gb := GBNPGroebnerBasis(Jtplus1,KQ);
+        gb := GroebnerBasisFunction(KQ)(Jtplus1,KQ);
         Jtplus1 := Ideal(KQ,Jtplus1); 
         gbb := GroebnerBasis(Jtplus1,gb);
         AA := KQ/Jtplus1;

--- a/lib/pathalg.gd
+++ b/lib/pathalg.gd
@@ -41,6 +41,7 @@ DeclareAttribute( "RelatorsOfFpAlgebra",
     IsQuotientOfPathAlgebra and IsFullFpPathAlgebra);
 DeclareAttribute( "RelationsOfAlgebra", IsQuiverAlgebra);
 DeclareAttribute( "IdealOfQuotient", IsQuiverAlgebra);
+DeclareAttribute( "GroebnerBasisFunction", IsQuiverAlgebra );
 DeclareAttribute( "NormalFormFunction", IsFamily );
 DeclareOperation( "ElementOfQuotientOfPathAlgebra", 
     [ IsElementOfQuotientOfPathAlgebraFamily, IsRingElement, IsBool ] );

--- a/lib/pathalgideal.gi
+++ b/lib/pathalgideal.gi
@@ -65,7 +65,7 @@ InstallTrueMethod( IsIdealInPathAlgebra,
 #O  \in(<elt>, <I>)
 ##
 ##  This function performs a membership test for an ideal in path algebra using 
-##  GBNP Groebner Bases machinery.
+##  Groebner Bases machinery.
 ##  It returns true if <elt> is a member of an ideal <I>, false otherwise.
 ##  For the efficiency reasons, it computes Groebner basis
 ##  for <I> only if it has not been computed. Similarly, it performs
@@ -103,7 +103,7 @@ InstallMethod(\in,
       else
         TryNextMethod();
       fi;      
-      GB := GBNPGroebnerBasis(rels, A);
+      GB := GroebnerBasisFunction(A)(rels, A);
       GB := GroebnerBasis(I, GB);
     fi;
 		
@@ -143,11 +143,13 @@ InstallMethod( IsAdmissibleIdeal,
       return IsFiniteDimensional(LeftActingRingOfIdeal(I)); # <=> (arrow ideal)^n \subset I, for some n
     fi;
   
+    A := LeftActingRingOfIdeal(I);
+
     if HasGroebnerBasisOfIdeal(I) then
       gb := GroebnerBasisOfIdeal(I);
     else
       rels := GeneratorsOfIdeal(I);     
-      gb := GBNPGroebnerBasis(rels, LeftActingRingOfIdeal(I));
+      gb := GroebnerBasisFunction(A)(rels, A);
       gb := GroebnerBasis(I, gb);
     fi;
     
@@ -169,7 +171,6 @@ InstallMethod( IsAdmissibleIdeal,
     # Dimension(J^{2n+2}).  If this dimension is different from zero, the ideal is not
     # admissible.  If this dimension is zero, then the ideal is admissible.
     # 
-    A := LeftActingRingOfIdeal(I);
     B := A/I;
     if IsFiniteDimensional(B) then
         arrows := List(ArrowsOfQuiver(QuiverOfPathAlgebra(B)), a -> One(B)*a);
@@ -226,7 +227,8 @@ InstallMethod( IsMonomialIdeal,
     if HasGroebnerBasisOfIdeal(I) then
       GB := GroebnerBasisOfIdeal(I);
     else
-      GB := GBNPGroebnerBasis(rels, LeftActingRingOfIdeal(I));
+      A := LeftActingRingOfIdeal(I);
+      GB := GroebnerBasisFunction(A)(rels, A);
       GB := GroebnerBasis(I, GB);
     fi;
     

--- a/lib/pathalgideal.gi
+++ b/lib/pathalgideal.gi
@@ -65,7 +65,7 @@ InstallTrueMethod( IsIdealInPathAlgebra,
 #O  \in(<elt>, <I>)
 ##
 ##  This function performs a membership test for an ideal in path algebra using 
-##  Groebner Bases machinery.
+##  (by default GBNP) Groebner Bases machinery.
 ##  It returns true if <elt> is a member of an ideal <I>, false otherwise.
 ##  For the efficiency reasons, it computes Groebner basis
 ##  for <I> only if it has not been computed. Similarly, it performs

--- a/lib/pathalgpredef.gi
+++ b/lib/pathalgpredef.gi
@@ -151,7 +151,7 @@ InstallMethod ( NakayamaAlgebra,
             return KQ;
         else
             I := Ideal(KQ,rels);
-            gb := GBNPGroebnerBasis(rels,KQ);
+            gb := GroebnerBasisFunction(KQ)(rels,KQ);
             gbb := GroebnerBasis(I,gb);
             A := KQ/I;
             SetFilterObj(A, IsNakayamaAlgebra and IsAdmissibleQuotientOfPathAlgebra );               
@@ -277,7 +277,7 @@ InstallMethod ( CanonicalAlgebra,
             Add(relations,arms[i] - arms[2] + relcoeff[i - 2]*arms[1]);
         od;
         I := Ideal(KQ,relations);
-        gb := GBNPGroebnerBasis(relations,KQ);
+        gb := GroebnerBasisFunction(KQ)(relations,KQ);
         gbb := GroebnerBasis(I,gb);
         A := KQ/I;
         SetFilterObj(A, IsCanonicalAlgebra and IsAdmissibleQuotientOfPathAlgebra );

--- a/lib/projpathalgmodule.gi
+++ b/lib/projpathalgmodule.gi
@@ -2234,7 +2234,7 @@ InstallMethod( ProjectivePathAlgebraPresentation,
     gens := GeneratorsOfTwoSidedIdeal(fam!.ideal);
     K := LeftActingDomain(A);
     I := Ideal(KQ,gens);
-    gb := GBNPGroebnerBasis(gens,KQ);
+    gb := GroebnerBasisFunction(KQ)(gens,KQ);
     gbb := GroebnerBasis(I,gb);
     rtgbofI := RightGroebnerBasis(I);
 

--- a/read.g
+++ b/read.g
@@ -23,6 +23,7 @@ ReadPackage("QPA", "lib/projpathalgmodule.gi");
 ReadPackage("QPA", "lib/moduledecomp.gi");
 ReadPackage("QPA", "lib/idempotent.gi");
 ReadPackage("QPA", "lib/gbnp.gi");
+ReadPackage("QPA", "lib/gbhighlevel.gi");
 ReadPackage("QPA", "lib/moduleprojres.gi");
 ReadPackage("QPA", "lib/pathalgtensor.gi");
 ReadPackage("QPA", "lib/pathalgpredef.gi");


### PR DESCRIPTION
This is an attempt to address #20 and replaces #21.

At the moment, `GBNPGroebnerBasis` is used at many places in the source. The first commit in this pull request replaces all occurrences of this function with a variable `GroebnerBasisFunction` so that QPA can [work with whatever package computing Groebner bases](https://github.com/gap-packages/qpa/pull/21#discussion_r221537732). The user may now specify as a third optional argument for `PathAlgebra` this `GroebnerBasisFunction`. By default nothing changes.

The second and third commit of this pull request define a function `HighLevelGroebnerBasis` as an alternative to `GBNPGroebnerBasis`. I wrote this as a temporary fix for #20.

Maybe it is enough to consider only the first commit for merging in case you think that the last two commits `045eab7` and `1afafbb` make the source code unnecessarily bloated and intransparent.