### PR TITLE
Add a mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+Øyvind Solberg <oyvind.solberg@ntnu.no>
+Øyvind Solberg <oyvind.solberg@ntnu.no> <sunnyquiver>
+Øyvind Solberg <oyvind.solberg@ntnu.no> <oyvind.solberg@math.ntnu.no>
+Øyvind Solberg <oyvind.solberg@ntnu.no> <sunnyquiver@users.noreply.github.com>
+Øyvind Solberg <oyvind.solberg@ntnu.no> <oyvinso@yvinds-MacBook-Pro.local>
+Øyvind Solberg <oyvind.solberg@ntnu.no> <oyvinso@euler.math.ntnu.no>
+Øyvind Solberg <oyvind.solberg@ntnu.no> <oyvinso@dhcp-15211.math.ntnu.no>
+Øystein Skartsæterhagen <oysteini@math.ntnu.no>
+Øystein Skartsæterhagen <oysteini@math.ntnu.no> <oysteini>
+Andrzej Mroz <amroz@mat.umk.pl>
+Andrzej Mroz <amroz@mat.umk.pl> <andrzejmroz>
+Andrzej Mroz <amroz@mat.umk.pl> <andrzejmroz@git.code.sf.net>
+Alexander Konovalov <alexk@mcs.st-andrews.ac.uk> <alex-konovalov@users.noreply.github.com>
+Kristin Krogh Arnesen <kristink@math.ntnu.no>
+Kristin Krogh Arnesen <kristink@math.ntnu.no> <kristink>


### PR DESCRIPTION
This way, the output of e.g. `git shortlog` or `git shortlog -sne` is more useful,
and also that of `git log` if use of mailmap is enabled in the config.