### PR TITLE
Allow an empty list of matrices in RightModuleOverPathAlgebra.

### DIFF
--- a/lib/module.gd
+++ b/lib/module.gd
@@ -8,6 +8,7 @@ DeclareCategoryCollections( "IsPathModuleElem" );
 DeclareGlobalFunction("PathModuleElem");
 DeclareCategory("IsBasisOfPathModuleElemVectorSpace", IsBasis);
 DeclareProperty("IsPathAlgebraMatModule", IsAlgebraModule);
+DeclareOperation("RightModuleOverPathAlgebra", [IsQuiverAlgebra, IsEmpty]);
 DeclareOperation("RightModuleOverPathAlgebra", [IsQuiverAlgebra, IsCollection]);
 DeclareOperation("RightModuleOverPathAlgebraNC", [IsQuiverAlgebra, IsCollection]);
 DeclareOperation("SubmoduleAsModule", [IsAlgebraModule]);

--- a/lib/module.gi
+++ b/lib/module.gi
@@ -404,6 +404,15 @@ end;
 InstallMethod(RightModuleOverPathAlgebra,
     "for a (quotient of a) path algebra and list of matrices",
     true,
+    [IsQuiverAlgebra, IsEmpty], 0,
+    function( R, gens )
+      return ZeroModule(R);
+end
+);
+
+InstallMethod(RightModuleOverPathAlgebra,
+    "for a (quotient of a) path algebra and list of matrices",
+    true,
     [IsQuiverAlgebra, IsCollection], 0,
     function( R, gens )
     local tempgens, a, dim, source, target, basis, i, x, Fam, 


### PR DESCRIPTION
If possible, I would like to be allowed to create the zero module with the following command:

`RightModuleOverPathAlgebra(A, []);`

This doesn't work at the moment since GAP Collections cannot be empty. With the changes in this commit the command above will work. But maybe there is a better way to implement it.