### PR TITLE
RightModuleOverPathAlgebra and isolated vertices.

### DIFF
--- a/lib/module.gd
+++ b/lib/module.gd
@@ -9,6 +9,7 @@ DeclareGlobalFunction("PathModuleElem");
 DeclareCategory("IsBasisOfPathModuleElemVectorSpace", IsBasis);
 DeclareProperty("IsPathAlgebraMatModule", IsAlgebraModule);
 DeclareOperation("RightModuleOverPathAlgebra", [IsQuiverAlgebra, IsCollection]);
+DeclareOperation("RightModuleOverPathAlgebraWithDimensionVector", [IsQuiverAlgebra, IsCollection, IsList]);
 DeclareOperation("RightModuleOverPathAlgebraNC", [IsQuiverAlgebra, IsCollection]);
 DeclareOperation("SubmoduleAsModule", [IsAlgebraModule]);
 DeclareOperation("BasisOfDomain", [IsFreeLeftModule and IsPathModuleElemCollection]);

--- a/lib/module.gi
+++ b/lib/module.gi
@@ -406,6 +406,17 @@ InstallMethod(RightModuleOverPathAlgebra,
     true,
     [IsQuiverAlgebra, IsCollection], 0,
     function( R, gens )
+      local dim_vector;
+      dim_vector := ListWithIdenticalEntries(NumberOfVertices(QuiverOfPathAlgebra(R)), 0);
+      return RightModuleOverPathAlgebraWithDimensionVector(R, gens, dim_vector);
+end
+);
+
+InstallMethod(RightModuleOverPathAlgebraWithDimensionVector,
+    "for a (quotient of a) path algebra and list of matrices",
+    true,
+    [IsQuiverAlgebra, IsCollection, IsList], 0,
+    function( R, gens, dim_vector_ )
     local tempgens, a, dim, source, target, basis, i, x, Fam, 
           vertices, matrices, quiver, M, vlist, alist, K, dim_M, 
           dim_vector, relationtest, I, terms, result, walk, matrix;
@@ -519,7 +530,7 @@ InstallMethod(RightModuleOverPathAlgebra,
   #
   for i in [ 1..Length( vertices ) ] do
       if vertices[ i ] = -1 then
-          vertices[ i ] := 0;
+          vertices[ i ] := dim_vector_[ i ];
       fi;
   od;
 #

--- a/lib/modulehom.gi
+++ b/lib/modulehom.gi
@@ -543,11 +543,7 @@ InstallMethod( SubRepresentationInclusion,
             Add(big_mat,[arrow,mat]);
         od;
         
-        if IsPathAlgebra(A) then 
-            submodule := RightModuleOverPathAlgebra(A,big_mat);
-        else
-            submodule := RightModuleOverPathAlgebra(A,big_mat); 
-        fi;      
+        submodule := RightModuleOverPathAlgebraWithDimensionVector(A,big_mat,dim_vect_sub);
 
 #
 # Finding inclusion map of submodule into M
@@ -908,11 +904,9 @@ InstallMethod ( ImageProjectionInclusion,
             fi;
             Add(image_mat,[a,mat]);
         od;
-        if IsPathAlgebra(A) then 
-            image_f := RightModuleOverPathAlgebra(A,image_mat);
-        else
-            image_f := RightModuleOverPathAlgebra(A,image_mat);
-        fi;
+
+        dim_image := List(basis_image, Length);
+        image_f := RightModuleOverPathAlgebraWithDimensionVector(A,image_mat,dim_image);
 #
 # Finding inclusion map from the image to Range(f)
 #     


### PR DESCRIPTION
At the moment, the version `RightModuleOverPathAlgebra(R, gens)` always assigns the zero vector space to isolated vertices. This is a problem since this version of `RightModuleOverPathAlgebra` is used at various places in the source of QPA, e.g. in `ImageProjectionInclusion` and `SubRepresentationInclusion`.

I wanted to address this problem simply by adding an optional argument `dim_vector` to the function `RightModuleOverPathAlgebra` to take care of the dimensions at isolated vertices. However, there already is another version `RightModuleOverPathAlgebra(A, dim_vector, gens)`. But there `gens` is assumed to take a different form as far as I can tell.

For this reason, I have introduced a new function `RightModuleOverPathAlgebraWithDimensionVector` (and applied it in `ImageProjectionInclusion` and `SubRepresentationInclusion`).

Would you prefer another solution? Or is there an easy way to use instead the already existing function `RightModuleOverPathAlgebra(A, dim_vector, gens)`?

I am also happy to cook up an example that illustrates the problem with the isolated vertices, if this description is not sufficient.