### PR TITLE
Fixed bug in Poset

### DIFF
--- a/lib/qpaposet.gi
+++ b/lib/qpaposet.gi
@@ -32,6 +32,7 @@ InstallMethod( Poset,
     # Defining the generating relations in the direct product <_P> x <_P>.
     #
     D := Domain( _P );
+    _P := Elements( D );
     rel := [];
     for r in _rel do
         for i in [ 2..Length( r ) ] do


### PR DESCRIPTION
This should fix #46 with a minimal change of code.

The problem is that positions of elements in `D := Domain( _P )`  are currently not computed correctly. They are only correct when `Domain` preserves the order of `_P`.