### PR TITLE
Gracefully accept the pluralization “1 generators” in test output

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,6 +1,23 @@
 LoadPackage("qpa");
 dir := DirectoriesPackageLibrary("qpa", "tst");
+
+# compareFunction: performing "uptowhitespace", and ignoring the incorrect
+# pluralisation "1 generators".
+# See https://github.com/gap-packages/qpa/issues/71
+func := function(a, b)
+  # Remove newlines
+  a := ReplacedString(ShallowCopy(a), "\\\n", "");
+  b := ReplacedString(ShallowCopy(b), "\\\n", "");
+  # Remove whitespace
+  RemoveCharacters(a, " \n\t\r");
+  RemoveCharacters(b, " \n\t\r");
+  # Remove (probably) incorrect pluralisation
+  a := ReplacedString(a, "1generators", "1generator");
+  b := ReplacedString(b, "1generators", "1generator");
+  return a = b;
+end;
+
 TestDirectory(dir, rec(exitGAP := true,
-                       testOptions:=rec(compareFunction:="uptowhitespace")));
+                       testOptions:=rec(compareFunction:=func)));
 
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
As well as comparing the expected and obtained test outputs up to whitespace, we now also consider "1 generator" and "1 generators" to be equivalent. This resolves #71.

The strategy is not completely bulletproof, since it would also consider "21 generators" and "21 generator" to be equivalent, but this should not occur, and even if it does, it only makes it easier to introduce a grammatical error (in pluralisation), not a mathematical error.