### PR TITLE
Fixed SaveAlgebra/ReadAlgebra for algebras with 11+ vertices

### DIFF
--- a/lib/pathalg.gi
+++ b/lib/pathalg.gi
@@ -2810,30 +2810,25 @@ InstallMethod ( SaveAlgebra,
     #
     # Storing vertices.
     #
-    number := 0;
+    number := 1;
     numberofvertices := Length( vertices );
     AppendTo( output, "Vertices:\n" );    
     temp := "";
-    for v in vertices do
-        if number > 0 then
-            temp := Concatenation( temp, ", ", String( v ) );
-        else
+
+    for v in vertices do 
+        if number = 1 then 
             temp := String( v );
+        elif number mod 10 = 1 then
+            temp := Concatenation( temp, ",\n", String( v ));
+        else 
+            temp := Concatenation( temp, ", ", String( v ));
+        fi;
+        if number = numberofvertices then 
+            WriteLine( output, temp );
+            break;
         fi;
         number := number + 1;
-        if number mod 10 = 0 then
-            if number = numberofvertices then
-                WriteLine( output, temp );
-            else 
-                temp := Concatenation( temp, "," );
-                WriteLine( output, temp );
-            fi;
-            temp := ""; 
-        fi;
     od;
-    if ( number = numberofvertices ) and ( number mod 10 <> 0 ) then
-        WriteLine( output, temp );
-    fi;
     #
     # Storing the arrows.
     #
@@ -2935,10 +2930,9 @@ InstallMethod ( ReadAlgebra,
     RemoveCharacters( temp, " " );
     vertices := SplitString( temp, "," );
     temp := NormalizedWhitespace( ReadLine( inputfile ) );
-        # Could use StartsWith below.
-    while temp{[ 1..6 ]} <> "Arrows" do
+    while not StartsWith(temp, "Arrows") do
         RemoveCharacters( temp, " " );
-        Append( vertices, SplitString( temp, "," ) );
+        Append( vertices, SplitString( temp, "", ", " ) );
         temp := NormalizedWhitespace( ReadLine( inputfile ) );
     od;
         #

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -1039,5 +1039,17 @@ function( x, y ) ... end
 gap> UnitForm([[2,1],[1,2]]);
 [ [ 2, 1 ], [ 1, 2 ] ]
 
+
+# 
+# Testing ReadAlgebra/SaveAlgebra
+gap> A := PathAlgebra(Rationals, DynkinQuiver("A", 11, ["r","r","r","r","r","r","r","r","r","r"]));
+<Rationals[<quiver with 11 vertices and 10 arrows>]>
+gap> SaveAlgebra(A, Filename(DirectoryCurrent(), "writealgebratest~"), "delete");
+true
+gap> ReadAlgebra("writealgebratest~");
+<Rationals[<quiver with 11 vertices and 10 arrows>]>
+gap> RemoveFile("writealgebratest~");
+true
+
 #
 gap> STOP_TEST("qpa.tst");


### PR DESCRIPTION
The ReadAlgebra and SaveAlgebra functions had bugs for algebras with 11 or more vertices. More precisely: When using SaveAlgebra on an algebra with vertices eg. 1,...,11 then they were stored in the file as follows:

```
Vertices:
1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
, 11
``` 
ReadAlgebra threw an error when trying to read such a file in. I rewrote the code to remove the redundant ", " in the second line, and made ReadAlgebra slightly more robust. I also added a simple test which stores an algebra with 11 vertices, then reads it back in (and deletes the file after).
