### PR TITLE
Fix some bugs related to isolated vertices

### DIFF
--- a/lib/module.gi
+++ b/lib/module.gi
@@ -1980,7 +1980,7 @@ InstallMethod ( RightAlgebraModuleToPathAlgebraMatModule,
     local A, vertices, num_vert, B, arrows, generators_in_vertices, 
           vertexwise_basis, i, j, vertices_Q, mat, arrows_as_paths, 
           a, partial_mat, source, target, source_index, target_index, 
-          rows, cols, arrow, b, vector;
+          rows, cols, arrow, b, vector, dimvect;
     
     if not IsFiniteDimensional(M) then
         Error("the entered module is not finite dimensional,\n");
@@ -2025,19 +2025,18 @@ InstallMethod ( RightAlgebraModuleToPathAlgebraMatModule,
         rows := Length(BasisVectors(vertexwise_basis[source_index]));
         cols := Length(BasisVectors(vertexwise_basis[target_index]));
         arrow := TipMonomial(a);
-        if ( rows = 0 or cols = 0 ) then
-            partial_mat := [arrow,[rows,cols]];
-            Add(mat,partial_mat);
-        else 
+        if rows <> 0 and cols <> 0 then
             for b in BasisVectors(vertexwise_basis[source_index]) do
                 vector := Coefficients(vertexwise_basis[target_index], b^a); 
                 Add(partial_mat,vector);
             od;
-            Add(mat,[arrow,partial_mat]);
+            Add(mat,[String(arrow),partial_mat]);
         fi;
     od;
     
-    return RightModuleOverPathAlgebra(A,mat);
+    dimvect := List(vertexwise_basis, b -> Length(b));
+    
+    return RightModuleOverPathAlgebra(A, dimvect, mat);
 end
   );
 
@@ -2233,7 +2232,7 @@ InstallMethod( RestrictionViaAlgebraHomomorphism,
     function( f, M )
 
     local   K,  A,  B,  vertices,  V,  BV,  arrows,  mats,  a,  
-            startpos,  endpos;
+            startpos,  endpos, dimvect;
     
     K := LeftActingDomain( M );
     A := Source( f );
@@ -2250,14 +2249,14 @@ InstallMethod( RestrictionViaAlgebraHomomorphism,
     for a in arrows do
         startpos := Position( vertices, One( A ) * SourceOfPath ( a ) );
         endpos := Position( vertices, One( A ) * TargetOfPath ( a ) );        
-        if IsEmpty( BV[ startpos ] ) or IsEmpty( BV[ endpos ] ) then
-            Add( mats, [ a, [ Length( BV[ startpos ] ), Length( BV[ endpos ] ) ] ] );
-        else
-            Add( mats, [ a, List( BV[ startpos ], m -> Coefficients( BV[ endpos ], m ^ ImageElm( f, One( A ) * a ) ) ) ] );
+        if not IsEmpty( BV[ startpos ] ) and not IsEmpty( BV[ endpos ] ) then
+            Add( mats, [ String(a), List( BV[ startpos ], m -> Coefficients( BV[ endpos ], m ^ ImageElm( f, One( A ) * a ) ) ) ] );
         fi;
     od;
     
-    return RightModuleOverPathAlgebra( A, mats ); 
+    dimvect := List(BV, b -> Length(b));
+    
+    return RightModuleOverPathAlgebra( A, dimvect, mats ); 
 end
   );
 

--- a/lib/modulehom.gi
+++ b/lib/modulehom.gi
@@ -533,20 +533,18 @@ InstallMethod( SubRepresentationInclusion,
             pi := Position(vertices,im_a);
             
             arrow := arrows_of_quiver[Position(arrows_as_path,a)];
-            if ( dim_vect_sub[pd] = 0 ) or ( dim_vect_sub[pi] = 0 ) then 
-                mat := [dim_vect_sub[pd],dim_vect_sub[pi]];
-            else 
+            if dim_vect_sub[pd] <> 0 and dim_vect_sub[pi] <> 0 then 
                 for m in submod_list{dim_size[pd]} do
                     Add(mat,Coefficients(basis_submod,Coefficients(basis_M,m^a)){dim_size[pi]}); 
                 od;
+                Add(big_mat,[String(arrow),mat]);
             fi;
-            Add(big_mat,[arrow,mat]);
         od;
         
         if IsPathAlgebra(A) then 
-            submodule := RightModuleOverPathAlgebra(A,big_mat);
+            submodule := RightModuleOverPathAlgebra(A, dim_vect_sub, big_mat);
         else
-            submodule := RightModuleOverPathAlgebra(A,big_mat); 
+            submodule := RightModuleOverPathAlgebra(A, dim_vect_sub, big_mat); 
         fi;      
 
 #
@@ -771,18 +769,16 @@ InstallMethod ( KernelInclusion,
 # the induced action on the basis of Ker f_i.
 #
         for a in arrows do
-            apos := Position(arrows,a);
             i := Position(vertices,SourceOfPath(a));
             j := Position(vertices,TargetOfPath(a));
-            matrix := [];
-            if ( dim_K[i] = 0 ) or ( dim_K[j] = 0 ) then 
-                matrix := [dim_K[i],dim_K[j]];
-            else 
+            if dim_K[i] <> 0 and dim_K[j] <> 0 then
+                apos := Position(arrows,a);
+                matrix := [];
                 for k in [1..Length(V_list[i])] do
                     Add(matrix,Coefficients(V_list[j],V_list[i][k]*mats[apos]));
                 od;
+                Add(kermats,[String(a),matrix]);
             fi;
-            Add(kermats,[a,matrix]);
         od;
 #
 # Extracting the basis vectors of each Ker f_i, as a subspace of M_i,
@@ -804,9 +800,9 @@ InstallMethod ( KernelInclusion,
             fi;
         od;
         if IsPathAlgebra(A) then 
-            Kerf := RightModuleOverPathAlgebra(A,kermats);
+            Kerf := RightModuleOverPathAlgebra(A, dim_K, kermats);
         else 
-            Kerf := RightModuleOverPathAlgebra(A,kermats);
+            Kerf := RightModuleOverPathAlgebra(A, dim_K, kermats);
         fi;
         kermap := RightModuleHomOverAlgebra(Kerf,M,V_list);
     fi;  
@@ -1110,7 +1106,7 @@ InstallMethod ( CoKernelProjection,
     local M, N, image, A, K, num_vert, vertices, arrows, basis_list,i, n, v,
           pos, dim_N, V, W, projection, coker, basis_coker, basis_N, a, b,
           mat, mats, source_a, target_a, pos_a, bb, cokermat, C, map, partmap,
-          morph;
+          morph, dimvec_coker;
 
     M := Source(f);
     N := Range(f);
@@ -1156,27 +1152,27 @@ InstallMethod ( CoKernelProjection,
     mats := MatricesOfPathAlgebraModule(N);
     arrows := ArrowsOfQuiver(QuiverOfPathAlgebra(A));
     cokermat := [];
-    for a in arrows do 
-        mat := [];
+    for a in arrows do
         source_a := Position(vertices,SourceOfPath(a)*One(A));
         target_a := Position(vertices,TargetOfPath(a)*One(A));
-        pos_a := Position(arrows,a);
-        if ( Length(basis_coker[source_a]) = 0 ) or ( Length(basis_coker[target_a]) = 0 ) then
-            mat := [Length(basis_coker[source_a]),Length(basis_coker[target_a])];
-        else  
+        if Length(basis_coker[source_a]) <> 0 and Length(basis_coker[target_a]) <> 0 then
+            mat := [];
+            pos_a := Position(arrows,a);
             for b in basis_coker[source_a] do
                 bb := PreImagesRepresentative(projection[source_a],b);
                 bb := bb*mats[pos_a]; # computing bb^a
                 Add(mat,Coefficients(basis_coker[target_a],Image(projection[target_a],bb)));
             od;
+            Add(cokermat,[String(a),mat]);
         fi;
-        Add(cokermat,[a,mat]);
     od;
     
-    if IsPathAlgebra(A) then 
-        C := RightModuleOverPathAlgebra(A,cokermat);
+    dimvec_coker := List(basis_coker, basis -> Length(basis));
+    
+    if IsPathAlgebra(A) then
+        C := RightModuleOverPathAlgebra(A, dimvec_coker, cokermat);
     else
-        C := RightModuleOverPathAlgebra(A,cokermat);
+        C := RightModuleOverPathAlgebra(A, dimvec_coker, cokermat);
     fi;
 #
 # Finding the map for Range(f) to the cokernel 

--- a/tst/testall.tst
+++ b/tst/testall.tst
@@ -1063,4 +1063,43 @@ gap> [e[1], e[2], e[3], e[4], e[5], e[6], e[7], e[8], e[9], e[10], e[11], e[12],
 [ v1, a1, a2, a1^2, a1*a2, a2*a1, a2^2, a1^3, a1^2*a2, a1*a2*a1, a1*a2^2, a2*a1^2, a2*a1*a2, a2^2*a1, a2^3, a1^4, a1^3*a2, a1^2*a2*a1, a1^2*a2^2, a1*a2*a1^2 ]
 
 
+
+
+
+#
+# Testing isolated vertices
+gap> Q := Quiver(3, [ [1, 2, "a"] ]);
+<quiver with 3 vertices and 1 arrows>
+gap> K := Rationals;
+Rationals
+gap> KQ := PathAlgebra(K, Q);
+<Rationals[<quiver with 3 vertices and 1 arrows>]>
+
+# Testing kernels and cokernels for isolated vertices:
+gap> module := RightModuleOverPathAlgebra(KQ, [1, 1, 2], [["a", [[1]]]]);
+<[ 1, 1, 2 ]>
+gap> homomorphism := RightModuleHomOverAlgebra(module, module, [ [[1]], [[1]], [ [1, 0], [0, 0] ]  ]);
+<<[ 1, 1, 2 ]> ---> <[ 1, 1, 2 ]>>
+gap> CoKernel(homomorphism);
+<[0, 0, 1]>
+gap> Kernel(homomorphism);
+<[0, 0, 1]>
+
+# Testing submodules for isolated vertices:
+gap> S := RightModuleOverPathAlgebra(KQ, [0, 0, 1], []);
+<[ 0, 0, 1 ]>
+gap> x := BasisVectors(Basis(S))[1];
+[ [ 0 ], [ 0 ], [ 1 ] ]
+gap> Source(SubRepresentationInclusion(S, [x]));
+<[0, 0, 1]>
+
+# Testing restrictions via algebra homomorphisms for isolated vertices:
+gap> RestrictionViaAlgebraHomomorphism(IdentityMapping(KQ), module);
+<[1, 1, 2]>
+
+# Testing RightAlgebraModuleToPathAlgebraMatModule for isolated vertices:
+gap> RightAlgebraModuleToPathAlgebraMatModule(module);
+<[ 1, 1, 2 ]>
+
+
 gap> STOP_TEST("qpa.tst");


### PR DESCRIPTION
The function `RightModuleOverPathAlgebra(A, mats)` assigns a zero-dimensional vector space to all isolated vertices, i.e. vertices that are not the source or target of any arrow. This causes bugs when some of QPA's methods are applied to quivers with isolated vertices: in some cases an incorrect result is returned, while in other cases an error occurs. This patch fixes most of these bugs (that I am aware of, at least) by using the function `RightModuleOverPathAlgebra(A, dim_vector, gens)` instead.

In addition to the methods I've updated, there are some methods using the function `RightModuleOverPathAlgebra(A, mats)` that I have not modified, namely the following:
- `1stSyzygy`: This method does not seem to have any bugs, as the syzygy of a module is zero at all isolated vertices.
- `SubmoduleAsModule`: This method seems to produce incorrect results in some cases,  but I don't really understand what sort of results it's actually supposed to produce, nor do I fully understand the source code, so I have not attempted to modify it.
- `NaturalHomomorphismBySubAlgebraModule`: I suspect that this method also produces incorrect results in some cases, but I haven't been able to find an example because I'm not sure what kind of input the method expects.

It might be relevant to update the last two of these methods at some point, but I've left them as they are for now.
