### PR TITLE
Fix bug in RightApproximationByAddM (list version)

### DIFF
--- a/lib/modulehomalg.gi
+++ b/lib/modulehomalg.gi
@@ -1969,7 +1969,7 @@ InstallMethod ( RightApproximationByAddM,
         homL_iapproxC := Filtered( homL_iapproxC, h -> not IsZero( h ) );
         endL_i := EndOverAlgebra( L[ i ] );
         radendL_i := RadicalOfAlgebra( endL_i );
-        RadendL_i := List( BasisVectors( Basis( radendL_i ) ), FromEndMToHomMM );
+        RadendL_i := List( BasisVectors( Basis( radendL_i ) ), x -> FromEndMToHomMM( L[i], x) );
         radmaps := Flat( List( homL_iC, h -> RadendL_i * h ) );
         generators := List( homL_iapproxC, h -> Flat( MatricesOfPathAlgebraMatModuleHomomorphism( h ) ) );
         radgenerators := List( radmaps, h -> Flat( MatricesOfPathAlgebraMatModuleHomomorphism( h ) ) );


### PR DESCRIPTION
Computing RightApproximationByAddM "for a list of modules and one module" on input where some module in the list has endomorphism algebra with nontrivial radical gives the following error message:
"Error, no 1st choice method found for `FromEndMToHomMM' on 1 arguments."
This pull request fixes that error.

The following code is a simple example for where an error occurs:
```
Q := Quiver(2, [[1,1,"a"], [1,2,"b"]]);
kQ := PathAlgebra(Rationals, Q);
AssignGeneratorVariables(kQ);
relations := [a^2];
gb := GBNPGroebnerBasis(relations, kQ);
I := Ideal(kQ, gb);
GroebnerBasis(I,gb);
A := kQ/I;

L := IndecProjectiveModules(A);
S := SimpleModules(A)[1];

RightApproximationByAddM(L, S);
```

Thanks to @ToshitakaAoki for discovering this bug.