### PR TITLE
Require GAP >= 4.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,8 +30,6 @@ jobs:
           - stable-4.13
           - stable-4.12
           - stable-4.11
-          - stable-4.10
-          - stable-4.9
 
     steps:
       - uses: actions/checkout@v5

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -82,7 +82,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.5",
+  GAP := ">=4.11",
   NeededOtherPackages := [["GBNP", ">=0.9.5"]],
   SuggestedOtherPackages := [],
   ExternalConditions := []


### PR DESCRIPTION
... as this package now uses Last() which was introduced then.
