### PR TITLE
README: update link to GAP installation instructions

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,7 @@ with GAP, so if you download this version or any later version QPA
 will be installed at the same time as GAP is installed.  Follow the
 instructions for installing GAP on the web page
 
-  https://www.gap-system.org/Download/index.html
+  https://www.gap-system.org/install/
 
 After having successfully started GAP, give the command
 


### PR DESCRIPTION
The old URL still works but it redirects to the new one.

(No need to make a new release for this)